### PR TITLE
Remote author's response now has proxy fields for "url" and "posts"

### DIFF
--- a/author/api/serializers.py
+++ b/author/api/serializers.py
@@ -50,6 +50,9 @@ class RemoteAuthorSerializer(serializers.Serializer):
         if 'url' in data:
             if not IsLocalURL(data['url'], request):
                 data['url'] = request.build_absolute_uri(reverse('remote_author-list', args=(data['url'],)))
+        if 'posts' in data:
+            if not IsLocalURL(data['posts'], request):
+                data['posts'] = request.build_absolute_uri(reverse('remote_post-list', args=(data['posts'],)))
         return data
 
 def SerializeAuthors(authors, request):

--- a/author/api/serializers.py
+++ b/author/api/serializers.py
@@ -1,7 +1,6 @@
 from rest_framework import serializers
 from django.core.urlresolvers import reverse
 from ..models import Author
-from django.core.urlresolvers import reverse
 from remotes.models import *
 from remotes.utils import *
 
@@ -40,6 +39,7 @@ class RemoteAuthorSerializer(serializers.Serializer):
     data = serializers.CharField(max_length=None)
 
     def to_representation(self, obj):
+        request = self.context['request']
         data = super(RemoteAuthorSerializer, self).to_representation(obj)
         jsonDict = json.loads(data['data'])
         for key in jsonDict:
@@ -48,8 +48,8 @@ class RemoteAuthorSerializer(serializers.Serializer):
         if 'username' not in data and 'displayName' in data:
             data['username'] = data['displayName']
         if 'url' in data:
-            if not IsLocalURL(data['url']):
-                data['url'] = reverse('remoteauthors-detail', args=(data['url'],))
+            if not IsLocalURL(data['url'], request):
+                data['url'] = request.build_absolute_uri(reverse('remote_author-list', args=(data['url'],)))
         return data
 
 def SerializeAuthors(authors, request):

--- a/author/api/serializers.py
+++ b/author/api/serializers.py
@@ -1,7 +1,9 @@
 from rest_framework import serializers
+from django.core.urlresolvers import reverse
 from ..models import Author
 from django.core.urlresolvers import reverse
 from remotes.models import *
+from remotes.utils import *
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
@@ -45,6 +47,9 @@ class RemoteAuthorSerializer(serializers.Serializer):
         del data['data']
         if 'username' not in data and 'displayName' in data:
             data['username'] = data['displayName']
+        if 'url' in data:
+            if not IsLocalURL(data['url']):
+                data['url'] = reverse('remoteauthors-detail', args=(data['url'],))
         return data
 
 def SerializeAuthors(authors, request):

--- a/author/api/serializers.py
+++ b/author/api/serializers.py
@@ -1,7 +1,8 @@
 from rest_framework import serializers
 from ..models import Author
 from django.core.urlresolvers import reverse
-
+from remotes.models import *
+from remotes.serializers import *
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
@@ -33,3 +34,16 @@ class UserSerializer(serializers.ModelSerializer):
             data['github'] = 'https://api.github.com/users/' + data['github'] + '/events'
         data['host'] = request.get_host()
         return data
+
+def SerializeAuthors(authors, request):
+    results = []
+    for author in authors:
+        if isinstance(author, Author):
+            serializer = UserSerializer(author, context={'request': request})
+            results.append(serializer.data)
+        elif isinstance(author, RemoteAuthor):
+            serializer = RemoteAuthorSerializer(author, context={'request': request})
+            results.append(serializer.data)
+        else:
+            raise Exception()
+    return results

--- a/author/api/serializers.py
+++ b/author/api/serializers.py
@@ -2,7 +2,6 @@ from rest_framework import serializers
 from ..models import Author
 from django.core.urlresolvers import reverse
 from remotes.models import *
-from remotes.serializers import *
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
@@ -33,6 +32,19 @@ class UserSerializer(serializers.ModelSerializer):
         if data['github'].find('github.com/') == -1:
             data['github'] = 'https://api.github.com/users/' + data['github'] + '/events'
         data['host'] = request.get_host()
+        return data
+
+class RemoteAuthorSerializer(serializers.Serializer):
+    data = serializers.CharField(max_length=None)
+
+    def to_representation(self, obj):
+        data = super(RemoteAuthorSerializer, self).to_representation(obj)
+        jsonDict = json.loads(data['data'])
+        for key in jsonDict:
+            data[key] = jsonDict[key]
+        del data['data']
+        if 'username' not in data and 'displayName' in data:
+            data['username'] = data['displayName']
         return data
 
 def SerializeAuthors(authors, request):

--- a/author/api/views.py
+++ b/author/api/views.py
@@ -64,6 +64,7 @@ class AuthorViewSet(viewsets.ModelViewSet):
 
     def list(self, request):
         queryset = Author.objects.all().filter(is_superuser=False).filter(is_active=True).order_by('-date_joined')
+        queryset = list(queryset)
 
         if request.user.is_anonymous() or (not IsRemoteAuthUser(request.user)):
             queryset += GetAllRemoteAuthors()

--- a/author/api/views.py
+++ b/author/api/views.py
@@ -121,6 +121,9 @@ class AuthorViewSet(viewsets.ModelViewSet):
             return super(AuthorViewSet, self).update(request, **kwargs)
 
 class RemoteAuthorViewSet(viewsets.ViewSet):
+    """
+    This is a remote author's profile
+    """
     authentication_classes = [BasicAuthentication, TokenAuthentication, SessionAuthentication]
 
     def list(self, request, remote_url):

--- a/author/api/views.py
+++ b/author/api/views.py
@@ -123,7 +123,10 @@ class AuthorViewSet(viewsets.ModelViewSet):
 class RemoteAuthorViewSet(viewsets.ViewSet):
     authentication_classes = [BasicAuthentication, TokenAuthentication, SessionAuthentication]
 
-    def retrieve(self, request, remote_url):
+    def list(self, request, remote_url):
         remoteAuthorDict = GetOneRemoteAuthor(remote_url)
-        serializer = RemoteAuthorSerializer(remoteAuthorDict, context={'request': request})
-        return HttpResponse(serializer.data)
+        if remoteAuthorDict is not None:
+            serializer = RemoteAuthorSerializer(remoteAuthorDict, context={'request': request})
+            return Response(serializer.data)
+        else:
+            return Response({'Error': 'Could not fetch url'}, status=404)

--- a/author/api/views.py
+++ b/author/api/views.py
@@ -10,7 +10,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.pagination import PageNumberPagination
 
 from permissions import IsAdminOrSelfOrReadOnly
-from serializers import UserSerializer, SerializeAuthors
+from serializers import UserSerializer, SerializeAuthors, RemoteAuthorSerializer
 from author.models import Author
 
 from remotes.utils import *
@@ -119,3 +119,11 @@ class AuthorViewSet(viewsets.ModelViewSet):
             return Response(serializer.data)
         else:
             return super(AuthorViewSet, self).update(request, **kwargs)
+
+class RemoteAuthorViewSet(viewsets.ViewSet):
+    authentication_classes = [BasicAuthentication, TokenAuthentication, SessionAuthentication]
+
+    def retrieve(self, request, remote_url):
+        remoteAuthorDict = GetOneRemoteAuthor(remote_url)
+        serializer = RemoteAuthorSerializer(remoteAuthorDict, context={'request': request})
+        return HttpResponse(serializer.data)

--- a/post/serializers.py
+++ b/post/serializers.py
@@ -121,6 +121,8 @@ class CommentReadSerializer(CommentWriteSerializer):
 
     def to_representation(self, obj):
         data = super(CommentReadSerializer, self).to_representation(obj)
+        data['comment'] = data['content']
+        data['pubDate'] = data['published']
         if 'local_author' in data and data['local_author'] is not None:
             data['author'] = data['local_author']
         elif data['remote_author_name'] != '':
@@ -130,6 +132,9 @@ class CommentReadSerializer(CommentWriteSerializer):
                 parsedURL = urlparse(data['remote_author_url'])
                 data['author']['host'] = parsedURL.netloc
             data['author']['github'] = ''
+        else:
+            data['author'] = {'ERROR': 'This comment has neither a local nor remote author', 'username': ''
+                              , 'displayName': '', 'url': '', 'host': '', 'github': ''}
         return data
 
 class CommentByPostSerializer(serializers.HyperlinkedModelSerializer):
@@ -151,6 +156,8 @@ class CommentByPostSerializer(serializers.HyperlinkedModelSerializer):
 
     def to_representation(self, obj):
         data = super(CommentByPostSerializer, self).to_representation(obj)
+        data['comment'] = data['content']
+        data['pubDate'] = data['published']
         if 'local_author' in data and data['local_author'] is not None:
             data['author'] = data['local_author']
         elif data['remote_author_name'] != '':
@@ -159,6 +166,10 @@ class CommentByPostSerializer(serializers.HyperlinkedModelSerializer):
                 data['author']['url'] = data['remote_author_url']
                 parsedURL = urlparse(data['remote_author_url'])
                 data['author']['host'] = parsedURL.netloc
+            data['author']['github'] = ''
+        else:
+            data['author'] = {'ERROR': 'This comment has neither a local nor remote author', 'username': ''
+                              , 'displayName': '', 'url': '', 'host': '', 'github': ''}
         return data
 
 # http://www.scriptscoop.net/t/7d698c5fe6de/using-django-rest-framework-how-can-i-upload-a-file-and-send-a-json-pa.html

--- a/post/serializers.py
+++ b/post/serializers.py
@@ -50,6 +50,14 @@ class PostReadSerializer(PostWriteSerializer):
         model = Post
         fields = ('id', 'url', 'title', 'content', 'author', 'published', 'privacy_level', 'privacy_host_only')
 
+    def to_representation(self, obj):
+        data = super(PostReadSerializer, self).to_representation(obj)
+        data['description'] = ''
+        data['categories'] = []
+        data['count'] = len(data['comments'])
+        data['size'] = len(data['comments'])
+        return data
+
 class RemotePostSerializer(serializers.Serializer):
     data = serializers.CharField(max_length=None)
     published = serializers.DateTimeField()

--- a/post/serializers.py
+++ b/post/serializers.py
@@ -59,6 +59,15 @@ class RemotePostSerializer(serializers.Serializer):
         for key in jsonDict:
             data[key] = jsonDict[key]
         del data['data']
+        if 'url' not in data and 'origin' in data:
+            data['url'] = data['origin']
+        if 'url' not in data and 'source' in data:
+            data['url'] = data['source']
+        if 'username' not in data and 'author' in data:
+            if 'username' in data['author']:
+                data['username'] = data['author']['username']
+            if 'displayName' in data['author']:
+                data['username'] = data['author']['displayName']
         return data
 
 def SerializePosts(posts, request):

--- a/post/views.py
+++ b/post/views.py
@@ -317,7 +317,7 @@ class CommentViewSet(viewsets.ModelViewSet):
 
         page = self.paginate_queryset(queryset)
         if page is not None:
-            serializer = self.get_serializer(page, many=True, context={'request': request})
+            serializer =CommentReadSerializer(page, many=True, context={'request': request})
             return self.get_paginated_response(serializer.data)
 
         serializer = CommentReadSerializer(queryset, many=True, context={'request': request})

--- a/post/views.py
+++ b/post/views.py
@@ -124,6 +124,26 @@ class PostByAuthor(viewsets.ViewSet, PagedViewMixin):
         serializer = PostReadSerializer(queryset, many=True, context={'request': request})
         return Response(serializer.data)
 
+class RemotePostsViewSet(viewsets.ViewSet, PagedViewMixin):
+    """
+    This is a set of remote posts (by one remote author)
+    """
+    authentication_classes = [BasicAuthentication, TokenAuthentication, SessionAuthentication]
+    pagination_class = PostPagination
+
+    def list(self, request, remote_url):
+        remotePostsDicts = GetRemotePostsAtUrl(remote_url, requestingUser = request.user)
+        if remotePostsDicts is not None:
+
+            page = self.paginate_queryset(remotePostsDicts)
+            if page is not None:
+                data = SerializePosts(page, request)
+                return self.get_paginated_response(data)
+
+            return Response({'Error': 'Failed to paginate'}, status=500)
+        else:
+            return Response({'Error': 'Could not fetch url'}, status=404)
+
 class MyPosts(PostByAuthor):
     """
     API endpoint for viewing Posts authored by current user

--- a/remotes/models.py
+++ b/remotes/models.py
@@ -27,3 +27,7 @@ class RemotePost(object):
             self.published = parse_datetime(data['pubDate'])
         else:
             raise BadDataException('No published date in RemotePost data')
+
+class RemoteAuthor(object):
+    def __init__(self, data):
+        self.data = json.dumps(data)

--- a/remotes/serializers.py
+++ b/remotes/serializers.py
@@ -4,3 +4,6 @@ from .models import *
 class RemotePostSerializer(serializers.Serializer):
 	data = serializers.CharField(max_length=None)
 	published = serializers.DateTimeField()
+
+class RemoteAuthorSerializer(serializers.Serializer):
+	data = serializers.CharField(max_length=None)

--- a/remotes/serializers.py
+++ b/remotes/serializers.py
@@ -1,9 +1,9 @@
 from rest_framework import serializers
 from .models import *
 
-class RemotePostSerializer(serializers.Serializer):
-	data = serializers.CharField(max_length=None)
-	published = serializers.DateTimeField()
-
-class RemoteAuthorSerializer(serializers.Serializer):
-	data = serializers.CharField(max_length=None)
+# class RemotePostSerializer(serializers.Serializer):
+# 	data = serializers.CharField(max_length=None)
+# 	published = serializers.DateTimeField()
+#
+# class RemoteAuthorSerializer(serializers.Serializer):
+# 	data = serializers.CharField(max_length=None)

--- a/remotes/utils.py
+++ b/remotes/utils.py
@@ -106,9 +106,15 @@ def GetOneRemoteAuthor(url, requestingUser = None):
         print('Warning: multiple servers matching {0}'.format(netloc))
     server = servers[0]
 
+    ind = url.find(server.host)
+    if ind == -1:
+        print('Error: problem with URL {0}'.format(url))
+        return None
+    path = url[ind+len(server.host):]
+
     # do the request
     try:
-        r = server.Get(parsedURL.path)
+        r = server.Get(path)
     except requests.exceptions.ConnectionError: # remote server down
         return None
 
@@ -122,6 +128,7 @@ def GetOneRemoteAuthor(url, requestingUser = None):
     return remoteAuthor
 
 def IsLocalURL(url, request):
-    parsedURL = urlparse(url)
-    parsedHostURL = urlparse(request.get_full_path())
-    return parsedHostURL.netloc in parsedURL
+    parsedHostURL = urlparse(request.build_absolute_uri())
+    print(parsedHostURL.netloc)
+    print(url)
+    return parsedHostURL.netloc in url

--- a/social_dist/api.py
+++ b/social_dist/api.py
@@ -1,6 +1,6 @@
 from rest_framework import routers
 from author.api.views import AuthorViewSet, RemoteAuthorViewSet
-from post.views import PostViewSet, CommentViewSet, ImageViewSet, PostByAuthor, MyPosts, CommentByPost
+from post.views import PostViewSet, CommentViewSet, ImageViewSet, PostByAuthor, MyPosts, CommentByPost, RemotePostsViewSet
 from follower.views import FollowViewSet, FriendViewSet, FriendlistViewSet
 
 # http://stackoverflow.com/questions/17496249/in-django-restframework-how-to-change-the-api-root-documentation
@@ -49,6 +49,7 @@ router.register(r'author/posts', PostViewSet, base_name='visible_posts')
 router.register(r'author/myposts', MyPosts, base_name='my_posts') # not required by the spec
 router.register(r'posts', PostViewSet)
 router.register(r'author/(?P<author_id>[0-9a-f\-]+)/posts', PostByAuthor, base_name='post_by_author')
+router.register(r'remoteposts/(?P<remote_url>.+)', RemotePostsViewSet, base_name='remote_post')
 
 # Comment views
 router.register(r'posts/(?P<post_id>[0-9a-f\-]+)/comments', CommentByPost, base_name='comment_by_post')
@@ -59,7 +60,7 @@ router.register(r'images', ImageViewSet)
 
 # Author views
 router.register(r'author', AuthorViewSet)
-router.register(r'remoteauthor/(?P<remote_url>.+)', RemoteAuthorViewSet, base_name='remote_author') # (?P<remote_url>.+)
+router.register(r'remoteauthor/(?P<remote_url>.+)', RemoteAuthorViewSet, base_name='remote_author')
 
 # Friend views TODO
 router.register(r'follow', FollowViewSet)

--- a/social_dist/api.py
+++ b/social_dist/api.py
@@ -1,5 +1,5 @@
 from rest_framework import routers
-from author.api.views import AuthorViewSet
+from author.api.views import AuthorViewSet, RemoteAuthorViewSet
 from post.views import PostViewSet, CommentViewSet, ImageViewSet, PostByAuthor, MyPosts, CommentByPost
 from follower.views import FollowViewSet, FriendViewSet, FriendlistViewSet
 
@@ -59,6 +59,7 @@ router.register(r'images', ImageViewSet)
 
 # Author views
 router.register(r'author', AuthorViewSet)
+router.register(r'remoteauthor/(?P<remote_url>[.*])', RemoteAuthorViewSet, base_name='remote_author')
 
 # Friend views TODO
 router.register(r'follow', FollowViewSet)

--- a/social_dist/api.py
+++ b/social_dist/api.py
@@ -59,7 +59,7 @@ router.register(r'images', ImageViewSet)
 
 # Author views
 router.register(r'author', AuthorViewSet)
-router.register(r'remoteauthor/(?P<remote_url>[.*])', RemoteAuthorViewSet, base_name='remote_author')
+router.register(r'remoteauthor/(?P<remote_url>.+)', RemoteAuthorViewSet, base_name='remote_author') # (?P<remote_url>.+)
 
 # Friend views TODO
 router.register(r'follow', FollowViewSet)


### PR DESCRIPTION
"url" and "posts" for remote authors now route to `/api/remoteauthor` and `/api/remoteposts`
